### PR TITLE
Database 활용한 동시성 문제 해결

### DIFF
--- a/coupon-stock/src/main/java/jpa/core/domain/Stock.java
+++ b/coupon-stock/src/main/java/jpa/core/domain/Stock.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Version;
 import jpa.core.exception.InvalidStockValueException;
 
 @Entity
@@ -16,6 +17,9 @@ public class Stock {
     private long productId;
 
     private long quantity;
+
+    @Version
+    private Long version;
 
     public Stock() {
     }

--- a/coupon-stock/src/main/java/jpa/core/facade/NamedLockStockFacade.java
+++ b/coupon-stock/src/main/java/jpa/core/facade/NamedLockStockFacade.java
@@ -1,0 +1,30 @@
+package jpa.core.facade;
+
+
+import jakarta.transaction.Transactional;
+import jpa.core.repository.LockRepository;
+import jpa.core.service.StockService;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NamedLockStockFacade {
+
+   private final LockRepository lockRepository;
+
+   private final StockService stockService;
+
+    public NamedLockStockFacade(LockRepository lockRepository, StockService stockService) {
+        this.lockRepository = lockRepository;
+        this.stockService = stockService;
+    }
+
+    @Transactional
+    public void decrease(Long id, Long quantity) {
+       try {
+           lockRepository.getLock(id.toString());
+           stockService.decrease(id, quantity);
+       } finally {
+           lockRepository.releaseLock(id.toString());
+       }
+    }
+}

--- a/coupon-stock/src/main/java/jpa/core/facade/OptimisticLockStockFacade.java
+++ b/coupon-stock/src/main/java/jpa/core/facade/OptimisticLockStockFacade.java
@@ -1,0 +1,26 @@
+package jpa.core.facade;
+
+import jpa.core.service.OptimisticLockStockService;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OptimisticLockStockFacade {
+
+    private final OptimisticLockStockService optimisticLockStockService;
+
+    public OptimisticLockStockFacade(OptimisticLockStockService optimisticLockStockService) {
+        this.optimisticLockStockService = optimisticLockStockService;
+    }
+
+    public void decrease(Long id, Long quantity) throws InterruptedException {
+        while (true) {
+            try {
+                optimisticLockStockService.decrease(id, quantity);
+
+                break;
+            } catch (Exception e) {
+                Thread.sleep(50);
+            }
+        }
+    }
+}

--- a/coupon-stock/src/main/java/jpa/core/repository/LockRepository.java
+++ b/coupon-stock/src/main/java/jpa/core/repository/LockRepository.java
@@ -1,0 +1,14 @@
+package jpa.core.repository;
+
+import jpa.core.domain.Stock;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface LockRepository extends JpaRepository<Stock, Long> {
+
+    @Query(value = "select get_lock(:key, 3000)", nativeQuery = true)
+    void getLock(String key);
+
+    @Query(value = "select release_lock(:key)", nativeQuery = true)
+    void releaseLock(String key);
+}

--- a/coupon-stock/src/main/java/jpa/core/repository/StockRepository.java
+++ b/coupon-stock/src/main/java/jpa/core/repository/StockRepository.java
@@ -11,4 +11,9 @@ public interface StockRepository extends JpaRepository<Stock, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select s from Stock s where s.id = :id")
     Stock findByIdWithPessimisticLock(Long id);
+
+
+    @Lock(LockModeType.OPTIMISTIC)
+    @Query("select s from Stock s where s.id = :id")
+    Stock findByIdWithOptimisticLock(Long id);
 }

--- a/coupon-stock/src/main/java/jpa/core/repository/StockRepository.java
+++ b/coupon-stock/src/main/java/jpa/core/repository/StockRepository.java
@@ -1,8 +1,14 @@
 package jpa.core.repository;
 
+import jakarta.persistence.LockModeType;
 import jpa.core.domain.Stock;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface StockRepository extends JpaRepository<Stock, Long> {
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select s from Stock s where s.id = :id")
+    Stock findByIdWithPessimisticLock(Long id);
 }

--- a/coupon-stock/src/main/java/jpa/core/service/OptimisticLockStockService.java
+++ b/coupon-stock/src/main/java/jpa/core/service/OptimisticLockStockService.java
@@ -1,0 +1,25 @@
+package jpa.core.service;
+
+import jakarta.transaction.Transactional;
+import jpa.core.domain.Stock;
+import jpa.core.repository.StockRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OptimisticLockStockService {
+
+    private final StockRepository stockRepository;
+
+    public OptimisticLockStockService(StockRepository stockRepository) {
+        this.stockRepository = stockRepository;
+    }
+
+    @Transactional
+    public void decrease(final Long id, Long quantity) {
+        Stock stock = stockRepository.findByIdWithOptimisticLock(id);
+
+        stock.decrease(quantity);
+
+        stockRepository.save(stock);
+    }
+}

--- a/coupon-stock/src/main/java/jpa/core/service/PessimisticLockStockService.java
+++ b/coupon-stock/src/main/java/jpa/core/service/PessimisticLockStockService.java
@@ -1,0 +1,25 @@
+package jpa.core.service;
+
+import jakarta.transaction.Transactional;
+import jpa.core.domain.Stock;
+import jpa.core.repository.StockRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PessimisticLockStockService {
+
+    private final StockRepository stockRepository;
+
+    public PessimisticLockStockService(StockRepository stockRepository) {
+        this.stockRepository = stockRepository;
+    }
+
+    @Transactional
+    public void decrease(final Long id, Long quantity) {
+        Stock stock = stockRepository.findByIdWithPessimisticLock(id);
+
+        stock.decrease(quantity);
+
+        stockRepository.save(stock);
+    }
+}

--- a/coupon-stock/src/main/java/jpa/core/service/StockService.java
+++ b/coupon-stock/src/main/java/jpa/core/service/StockService.java
@@ -3,6 +3,8 @@ package jpa.core.service;
 import jpa.core.domain.Stock;
 import jpa.core.repository.StockRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class StockService {
@@ -13,7 +15,8 @@ public class StockService {
         this.stockRepository = stockRepository;
     }
 
-    public synchronized void decrease(Long id, Long quantity) {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void decrease(Long id, Long quantity) {
         Stock stock = stockRepository.findById(id).orElseThrow();
         stock.decrease(quantity);
 

--- a/coupon-stock/src/main/java/jpa/core/service/StockService.java
+++ b/coupon-stock/src/main/java/jpa/core/service/StockService.java
@@ -21,3 +21,4 @@ public class StockService {
     }
 
 }
+

--- a/coupon-stock/src/main/resources/application.yaml
+++ b/coupon-stock/src/main/resources/application.yaml
@@ -11,6 +11,8 @@ spring:
     username: root
     password: root
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 40
 
   jpa:
     hibernate:

--- a/coupon-stock/src/test/java/jpa/core/facade/NamedLockStockFacadeTest.java
+++ b/coupon-stock/src/test/java/jpa/core/facade/NamedLockStockFacadeTest.java
@@ -1,0 +1,58 @@
+package jpa.core.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import jpa.core.domain.Stock;
+import jpa.core.repository.StockRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class NamedLockStockFacadeTest {
+
+    @Autowired
+    private NamedLockStockFacade namedLockStockFacade;
+
+    @Autowired
+    private StockRepository stockRepository;
+
+    @BeforeEach
+    public void setUp() {
+        stockRepository.save(new Stock(1L, 100L));
+    }
+
+    @AfterEach
+    public void after() {
+        stockRepository.deleteAll();
+    }
+
+    @Test
+    public void decrementInventoryConcurrently() throws InterruptedException {
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    namedLockStockFacade.decrease(1L, 1L);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        Stock stock = stockRepository.findById(1L).orElseThrow();
+
+        assertThat(stock.getQuantity()).isEqualTo(0);
+    }
+}

--- a/coupon-stock/src/test/java/jpa/core/facade/OptimisticLockStockFacadeTest.java
+++ b/coupon-stock/src/test/java/jpa/core/facade/OptimisticLockStockFacadeTest.java
@@ -1,0 +1,59 @@
+package jpa.core.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import jpa.core.domain.Stock;
+import jpa.core.repository.StockRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class OptimisticLockStockFacadeTest {
+
+    @Autowired
+    private OptimisticLockStockFacade optimisticLockStockFacade;
+
+    @Autowired
+    private StockRepository stockRepository;
+
+    @BeforeEach
+    public void setUp() {
+        stockRepository.save(new Stock(1L, 100L));
+    }
+
+    @AfterEach
+    public void after() {
+        stockRepository.deleteAll();
+    }
+
+    @Test
+    public void decrementInventoryConcurrently() throws InterruptedException {
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    optimisticLockStockFacade.decrease(1L, 1L);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        Stock stock = stockRepository.findById(1L).orElseThrow();
+
+        assertThat(stock.getQuantity()).isEqualTo(0);
+    }
+}

--- a/coupon-stock/src/test/java/jpa/core/service/PessimisticLockStockServiceTest.java
+++ b/coupon-stock/src/test/java/jpa/core/service/PessimisticLockStockServiceTest.java
@@ -1,0 +1,57 @@
+package jpa.core.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import jpa.core.domain.Stock;
+import jpa.core.repository.StockRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class PessimisticLockStockServiceTest {
+
+    @Autowired
+    private PessimisticLockStockService pessimisticLockStockService;
+
+    @Autowired
+    private StockRepository stockRepository;
+
+    @BeforeEach
+    public void setUp() {
+       stockRepository.save(new Stock(1L, 100L));
+    }
+
+    @AfterEach
+    public void after() {
+        stockRepository.deleteAll();;
+    }
+
+    @Test
+    public void decrementInventoryConcurrently() throws InterruptedException {
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    pessimisticLockStockService.decrease(1L, 1L);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        Stock stock = stockRepository.findById(1L).orElseThrow();
+
+        assertThat(stock.getQuantity()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
- StockRepository에 비관적 락을 사용하여 Stock 엔티티를 조회하는 findByIdWithPessimisticLock 메서드 추가
- PessimisticLockStockService 클래스 생성 및 비관적 락을 사용하여 재고 감소 로직 구현
- 비관적 락을 사용한 재고 감소 기능의 동시성 테스트 (PessimisticLockStockServiceTest) 추가
- 이번 변경 사항은 동시성 문제를 해결하기 위해 비관적 락(Pessimistic Lock)을 사용한 재고 감소 기능을 추가하고, 관련 테스트 코드를 작성했습니다. 이를 통해 동시에 여러 요청이 들어와도 데이터의 일관성을 유지할 수 있게 되었습니다.