### PR TITLE
스프링 핵심 원리 - 의존관계 주입

### DIFF
--- a/spring-basic/build.gradle
+++ b/spring-basic/build.gradle
@@ -21,6 +21,18 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	compileOnly 'org.projectlombok:lombok:1.18.36'
+	annotationProcessor 'org.projectlombok:lombok:1.18.36'
+
+	testCompileOnly 'org.projectlombok:lombok:1.18.36'
+	testAnnotationProcessor 'org.projectlombok:lombok:1.18.36'
+}
+
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
 }
 
 tasks.named('test') {

--- a/spring-basic/src/main/java/hello/core/annotation/MainDiscountPolicy.java
+++ b/spring-basic/src/main/java/hello/core/annotation/MainDiscountPolicy.java
@@ -1,0 +1,17 @@
+package hello.core.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER,
+    ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Qualifier("mainDiscountPolicy")
+public @interface MainDiscountPolicy {
+
+}

--- a/spring-basic/src/main/java/hello/core/discount/FixDiscountPolicy.java
+++ b/spring-basic/src/main/java/hello/core/discount/FixDiscountPolicy.java
@@ -2,7 +2,11 @@ package hello.core.discount;
 
 import hello.core.member.Grade;
 import hello.core.member.Member;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
 
+@Component
+@Qualifier("fixDisCount")
 public class FixDiscountPolicy implements DiscountPolicy {
 
     private final int discountFixAmount = 1000;

--- a/spring-basic/src/main/java/hello/core/discount/RateDiscountPolicy.java
+++ b/spring-basic/src/main/java/hello/core/discount/RateDiscountPolicy.java
@@ -2,9 +2,11 @@ package hello.core.discount;
 
 import hello.core.member.Grade;
 import hello.core.member.Member;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 @Component
+@Primary
 public class RateDiscountPolicy implements DiscountPolicy {
 
     private int discountPercent = 10;

--- a/spring-basic/src/main/java/hello/core/discount/RateDiscountPolicy.java
+++ b/spring-basic/src/main/java/hello/core/discount/RateDiscountPolicy.java
@@ -1,12 +1,12 @@
 package hello.core.discount;
 
+import hello.core.annotation.MainDiscountPolicy;
 import hello.core.member.Grade;
 import hello.core.member.Member;
-import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 @Component
-@Primary
+@MainDiscountPolicy
 public class RateDiscountPolicy implements DiscountPolicy {
 
     private int discountPercent = 10;

--- a/spring-basic/src/main/java/hello/core/member/MemberServiceImpl.java
+++ b/spring-basic/src/main/java/hello/core/member/MemberServiceImpl.java
@@ -1,6 +1,5 @@
 package hello.core.member;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -8,7 +7,6 @@ public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
 
-    @Autowired
     public MemberServiceImpl(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
     }

--- a/spring-basic/src/main/java/hello/core/member/MemberServiceImpl.java
+++ b/spring-basic/src/main/java/hello/core/member/MemberServiceImpl.java
@@ -1,15 +1,13 @@
 package hello.core.member;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
-
-    public MemberServiceImpl(MemberRepository memberRepository) {
-        this.memberRepository = memberRepository;
-    }
 
     @Override
     public void join(Member member) {

--- a/spring-basic/src/main/java/hello/core/order/OrderServiceImpl.java
+++ b/spring-basic/src/main/java/hello/core/order/OrderServiceImpl.java
@@ -3,7 +3,6 @@ package hello.core.order;
 import hello.core.discount.DiscountPolicy;
 import hello.core.member.Member;
 import hello.core.member.MemberRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -12,7 +11,6 @@ public class OrderServiceImpl implements OrderService {
     private final MemberRepository memberRepository;
     private final DiscountPolicy discountPolicy;
 
-    @Autowired
     public OrderServiceImpl(MemberRepository memberRepository, DiscountPolicy discountPolicy) {
         this.memberRepository = memberRepository;
         this.discountPolicy = discountPolicy;

--- a/spring-basic/src/main/java/hello/core/order/OrderServiceImpl.java
+++ b/spring-basic/src/main/java/hello/core/order/OrderServiceImpl.java
@@ -3,15 +3,21 @@ package hello.core.order;
 import hello.core.discount.DiscountPolicy;
 import hello.core.member.Member;
 import hello.core.member.MemberRepository;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 public class OrderServiceImpl implements OrderService {
 
     private final MemberRepository memberRepository;
     private final DiscountPolicy discountPolicy;
+
+    @Autowired
+    public OrderServiceImpl(MemberRepository memberRepository, @Qualifier("fixDisCount") DiscountPolicy discountPolicy) {
+        this.memberRepository = memberRepository;
+        this.discountPolicy = discountPolicy;
+    }
 
     @Override
     public Order createOrder(Long memberId, String itemName, int itemPrice) {

--- a/spring-basic/src/main/java/hello/core/order/OrderServiceImpl.java
+++ b/spring-basic/src/main/java/hello/core/order/OrderServiceImpl.java
@@ -1,5 +1,6 @@
 package hello.core.order;
 
+import hello.core.annotation.MainDiscountPolicy;
 import hello.core.discount.DiscountPolicy;
 import hello.core.member.Member;
 import hello.core.member.MemberRepository;
@@ -14,7 +15,7 @@ public class OrderServiceImpl implements OrderService {
     private final DiscountPolicy discountPolicy;
 
     @Autowired
-    public OrderServiceImpl(MemberRepository memberRepository, @Qualifier("fixDisCount") DiscountPolicy discountPolicy) {
+    public OrderServiceImpl(MemberRepository memberRepository, @MainDiscountPolicy DiscountPolicy discountPolicy) {
         this.memberRepository = memberRepository;
         this.discountPolicy = discountPolicy;
     }

--- a/spring-basic/src/main/java/hello/core/order/OrderServiceImpl.java
+++ b/spring-basic/src/main/java/hello/core/order/OrderServiceImpl.java
@@ -3,18 +3,15 @@ package hello.core.order;
 import hello.core.discount.DiscountPolicy;
 import hello.core.member.Member;
 import hello.core.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class OrderServiceImpl implements OrderService {
 
     private final MemberRepository memberRepository;
     private final DiscountPolicy discountPolicy;
-
-    public OrderServiceImpl(MemberRepository memberRepository, DiscountPolicy discountPolicy) {
-        this.memberRepository = memberRepository;
-        this.discountPolicy = discountPolicy;
-    }
 
     @Override
     public Order createOrder(Long memberId, String itemName, int itemPrice) {

--- a/spring-basic/src/main/java/hello/core/order/OrderServiceImpl.java
+++ b/spring-basic/src/main/java/hello/core/order/OrderServiceImpl.java
@@ -5,7 +5,6 @@ import hello.core.discount.DiscountPolicy;
 import hello.core.member.Member;
 import hello.core.member.MemberRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/spring-basic/src/test/java/hello/core/autowried/AllBeanTest.java
+++ b/spring-basic/src/test/java/hello/core/autowried/AllBeanTest.java
@@ -1,0 +1,50 @@
+package hello.core.autowried;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import hello.core.AutoAppConfig;
+import hello.core.discount.DiscountPolicy;
+import hello.core.member.Grade;
+import hello.core.member.Member;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+public class AllBeanTest {
+
+    @Test
+    void findAllBean() {
+        ApplicationContext ac = new
+            AnnotationConfigApplicationContext(AutoAppConfig.class, DiscountService.class);
+
+        DiscountService discountService = ac.getBean(DiscountService.class);
+
+        Member member = new Member(1L, "userA", Grade.VIP);
+        int discountPrice = discountService.discount(member, 10000,
+            "fixDiscountPolicy");
+
+        assertThat(discountService).isInstanceOf(DiscountService.class);
+        assertThat(discountPrice).isEqualTo(1000);
+    }
+
+    static class DiscountService {
+
+        private final Map<String, DiscountPolicy> policyMap;
+        private final List<DiscountPolicy> policies;
+
+        public DiscountService(Map<String, DiscountPolicy> policyMap,
+            List<DiscountPolicy> policies) {
+            this.policyMap = policyMap;
+            this.policies = policies;
+        }
+
+        public int discount(Member member, int price, String discountCode) {
+            DiscountPolicy discountPolicy = policyMap.get(discountCode);
+            System.out.println("discountCode = " + discountCode);
+            System.out.println("discountPolicy = " + discountPolicy);
+            return discountPolicy.discount(member, price);
+        }
+    }
+}

--- a/spring-basic/src/test/java/hello/core/autowried/AutowiredTest.java
+++ b/spring-basic/src/test/java/hello/core/autowried/AutowiredTest.java
@@ -1,0 +1,37 @@
+package hello.core.autowried;
+
+import hello.core.member.Member;
+import jakarta.annotation.Nullable;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+public class AutowiredTest {
+
+    @Test
+    void AutowiredOption() {
+        ApplicationContext applicationContext = new AnnotationConfigApplicationContext(
+            TestBean.class);
+
+    }
+
+    static class TestBean {
+
+        @Autowired(required = false)
+        public void setNoBean1(Member noBean1) {
+            System.out.println("noBean1 = " + noBean1);
+        }
+
+        @Autowired
+        public void setNoBean2(@Nullable Member noBean2) {
+            System.out.println("noBean2 = " + noBean2);
+        }
+
+        @Autowired
+        public void setNoBean3(Optional<Member> noBean3) {
+            System.out.println("noBean3 = " + noBean3);
+        }
+    }
+}


### PR DESCRIPTION
스프링 공식문서에 따르면 하나의 생성자만 정의하는 경우 이러한 생성자에 대한 Autowired 어노테이션은 더 이상 필요하지 않습니다. 라고 합니다. 때문에 명시적으로 autowired을 표시하면 좋지만 공식문서에도 권장하지 않는 방법으로 제거합니다.

seeAlso:
- https://docs.spring.io/spring-framework/reference/core/beans/annotation-config/autowired.html